### PR TITLE
feat: add onComplete methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ yarn add react-daum-address-hook
 ```tsx
 import { useAddressSearch } from "react-daum-address-hook";
 const AddressSearch = () => {
-  const { selectedAddress, openSearch, isReady } = useAddressSearch();
+  // NOTE: onComplete is optional
+  const { selectedAddress, openSearch, isReady } = useAddressSearch({
+    onComplete: (data) => {
+      setValue("postalCode", data.zonecode);
+      setValue("address", `${data.address} ${data.buildingName || ""}`);
+    },
+  });
   console.log(selectedAddress);
   return (
     <div style={{ padding: "20px" }}>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-daum-address-hook",
-  "version": "1.0.2",
+  "version": "1.1.2",
   "description": "A lightweight and modern React hook for Daum(Kakao) address search service with TypeScript support",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/useAddressSearch.ts
+++ b/src/useAddressSearch.ts
@@ -16,8 +16,13 @@ declare global {
     };
   }
 }
+interface UseAddressSearchProps {
+  onComplete?: (data: AddressSearchResult) => void;
+}
 
-export const useAddressSearch = (): UseAddressSearch => {
+export const useAddressSearch = (
+  props?: UseAddressSearchProps
+): UseAddressSearch => {
   const [selectedAddress, setSelectedAddress] =
     useState<AddressSearchResult | null>(null);
   const [isScriptLoaded, setIsScriptLoaded] = useState(false);
@@ -46,6 +51,7 @@ export const useAddressSearch = (): UseAddressSearch => {
       await new window.daum.Postcode({
         oncomplete: (data: AddressSearchResult) => {
           setSelectedAddress(data);
+          props?.onComplete?.(data);
         },
       }).open();
     } catch (error) {


### PR DESCRIPTION
# Changes
- Added optional `onComplete` callback to useAddressSearch hook

## Why
- Enables direct handling of address selection without relying on side effects
- Provides more flexibility in how address data can be used immediately after selection
- Reduces the need for useEffect when integrating with form libraries or other state management solutions

## Technical Details
- Added optional onComplete callback parameter to handle address selection events
- Maintains backward compatibility with existing implementation
- Callback is safely handled with optional chaining to prevent runtime errors
- Existing selectedAddress state management remains unchanged

## Example Usage
```typescript
const { openSearch } = useAddressSearch({
  onComplete: (data) => {
    setValue('postalCode', data.zonecode);
    setValue('address', data.address);
  }
});